### PR TITLE
adminが全てのメッセージを見られるようにruleを変更

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,6 +3,9 @@ service cloud.firestore {
     function isAuthenticated() {
       return request.auth.uid != null;
     }
+    function isAdmin() {
+      return request.auth.uid == 'admin';
+    }
     function isSentFromCorrectId() {
       return request.auth.uid == request.resource.data.sentFromAccountId;
     }
@@ -21,11 +24,11 @@ service cloud.firestore {
 
     match /rooms/{roomId} {
       allow list: if isAuthenticated()
-                  && isUserInRoom(resource.data, request.auth.uid);
+                  && (isUserInRoom(resource.data, request.auth.uid) || isAdmin());
 
       match /messages/{messageId} {
         allow read: if isAuthenticated()
-                    && isUserInRoomByFetch(roomId);
+                    && (isUserInRoomByFetch(roomId) || isAdmin());
         allow create: if isAuthenticated()
                       && isUserInRoomByFetch(roomId)
                       && isSentFromCorrectId()


### PR DESCRIPTION
管理画面で管理者がクライアントとキャストのメッセージを見る必要があるので、firestore rulesを編集しました。